### PR TITLE
Fix WebDAV path handling

### DIFF
--- a/obsidian_api.py
+++ b/obsidian_api.py
@@ -15,6 +15,22 @@ PASSWORD = "Xkntc-ypdG5-3SL5H-NP2GX-4YC9W"
 WEBDAV_BASE_URL = "https://cloud.barch.com.br/remote.php/dav/files/Gustavo/Barch%20Adm/03.Recursos/ObsidianVault/Gustavo/"
 AUTH = HTTPBasicAuth(USERNAME, PASSWORD)
 
+
+def to_relative_path(raw_path: str) -> str:
+    """Converte o caminho WebDAV completo em um caminho relativo ao cofre."""
+    path = unquote(raw_path)
+
+    # Caminho base com e sem o domínio
+    base_with_domain = WEBDAV_BASE_URL
+    base_without_domain = WEBDAV_BASE_URL.replace("https://cloud.barch.com.br", "")
+
+    if path.startswith(base_with_domain):
+        path = path[len(base_with_domain):]
+    elif path.startswith(base_without_domain):
+        path = path[len(base_without_domain):]
+
+    return path.strip("/")
+
 # === LISTAR NOTAS ===
 @app.route("/notes")
 def list_notes():
@@ -41,7 +57,7 @@ def list_notes():
         if "Attachments" in path or "Readwise" in path:
             continue
 
-        rel_path = path.replace(WEBDAV_BASE_URL.replace("https://cloud.barch.com.br", ""), "").strip("/")
+        rel_path = to_relative_path(elem.text)
         
         if folder_filter and not rel_path.startswith(folder_filter):
             continue
@@ -64,7 +80,7 @@ def list_notes():
 def get_note(filename):
     # Proteção contra input incorreto vindo com o WebDAV completo
     if "remote.php/dav/files/" in filename:
-        filename = filename.split("ObsidianVault/Gustavo/", 1)[-1]
+        filename = to_relative_path(filename)
 
     file_url = WEBDAV_BASE_URL + quote(filename)
     res = requests.get(file_url, auth=AUTH)
@@ -96,7 +112,7 @@ def list_folders():
         if "Attachments" in path or "Readwise" in path:
             continue
 
-        rel_path = path.replace(WEBDAV_BASE_URL.replace("https://cloud.barch.com.br", ""), "").strip("/")
+        rel_path = to_relative_path(elem.text)
         folder = os.path.dirname(rel_path)
         folders.add(folder)
 
@@ -122,14 +138,11 @@ def search_notes():
     max_results = 30  # Evita travamento com muitos arquivos
 
     for elem in tree.findall(".//{DAV:}href"):
-        from urllib.parse import unquote
-        import os
-
         path = unquote(elem.text)
         if not path.endswith(".md") or "Attachments" in path or "Readwise" in path:
             continue
 
-        rel_path = path.replace(WEBDAV_BASE_URL.replace("https://cloud.barch.com.br", ""), "").strip("/")
+        rel_path = to_relative_path(elem.text)
         file_url = WEBDAV_BASE_URL + quote(rel_path)
         try:
             file_res = requests.get(file_url, auth=AUTH)
@@ -159,7 +172,7 @@ def create_or_update_note():
 
     # Corrigir se o filename vier com prefixo WebDAV completo
     if "remote.php/dav/files" in filename:
-        filename = filename.split("ObsidianVault/Gustavo/", 1)[-1]
+        filename = to_relative_path(filename)
 
     file_url = WEBDAV_BASE_URL + quote(filename)
     res = requests.put(file_url, data=content.encode("utf-8"), auth=AUTH)


### PR DESCRIPTION
## Summary
- add helper `to_relative_path` to normalize WebDAV paths
- fix usage in notes, folders, search and save endpoints

## Testing
- `python -m py_compile obsidian_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6855a4cb18a8832580d74bec8719a7df