### PR TITLE
Fix trailing whitespace

### DIFF
--- a/obsidian_api.py
+++ b/obsidian_api.py
@@ -42,7 +42,7 @@ def list_notes():
             continue
 
         rel_path = path.replace(WEBDAV_BASE_URL.replace("https://cloud.barch.com.br", ""), "").strip("/")
-        
+
         if folder_filter and not rel_path.startswith(folder_filter):
             continue
         if query and query not in rel_path.lower():


### PR DESCRIPTION
## Summary
- trim trailing spaces after `rel_path` assignment

## Testing
- `python -m py_compile obsidian_api.py`


------
https://chatgpt.com/codex/tasks/task_e_6855a622791c8325bdecb56ed25d69c6