### PR TITLE
Handle missing JSON in note creation

### DIFF
--- a/obsidian_api.py
+++ b/obsidian_api.py
@@ -150,7 +150,13 @@ def search_notes():
 # === CRIAR NOTA ===
 @app.route("/note", methods=["POST"])
 def create_or_update_note():
+    if not request.is_json:
+        return jsonify({"error": "Corpo da requisi\u00e7\u00e3o deve ser JSON"}), 400
+
     data = request.get_json()
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON inv\u00e1lido"}), 400
+
     filename = data.get("filename")
     content = data.get("content", "")
 


### PR DESCRIPTION
## Summary
- validate request JSON in `create_or_update_note`

## Testing
- `python -m py_compile obsidian_api.py`


------
https://chatgpt.com/codex/tasks/task_e_6855a6243ba88325a3ef295c2f229333