### PR TITLE
Add install step and list pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ Você pode desconectar ou excluir a API a qualquer momento para encerrar o acess
 
 ## Running tests
 
-Install the requirements and run `pytest` from the repository root:
+Primeiro instale as dependências e depois execute `pytest` a partir do diretório
+raiz do projeto:
 
 ```bash
+pip install -r requirements.txt
 pytest
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
 requests
 flask_cors
+pytest


### PR DESCRIPTION
## Summary
- mention installing dependencies before running tests
- add pytest to requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement flask)*
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6855a9c83e108325af1344cb4a3ce3fb