### PR TITLE
Remove redundant imports in API

### DIFF
--- a/obsidian_api.py
+++ b/obsidian_api.py
@@ -18,8 +18,6 @@ AUTH = HTTPBasicAuth(USERNAME, PASSWORD)
 # === LISTAR NOTAS ===
 @app.route("/notes")
 def list_notes():
-    from urllib.parse import unquote
-    import os
 
     query = request.args.get("q", "").lower()
     folder_filter = request.args.get("folder", "")
@@ -122,9 +120,6 @@ def search_notes():
     max_results = 30  # Evita travamento com muitos arquivos
 
     for elem in tree.findall(".//{DAV:}href"):
-        from urllib.parse import unquote
-        import os
-
         path = unquote(elem.text)
         if not path.endswith(".md") or "Attachments" in path or "Readwise" in path:
             continue


### PR DESCRIPTION
## Summary
- drop unnecessary imports inside `list_notes` and `search_notes`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'obsidian_api')*

------
https://chatgpt.com/codex/tasks/task_e_6855a9cad2e4832592c6a181c87d9524