### PR TITLE
Fix relative path logic and reuse helper

### DIFF
--- a/obsidian_api.py
+++ b/obsidian_api.py
@@ -26,8 +26,10 @@ def to_relative_path(raw_path: str) -> str:
     path = unquote(raw_path)
 
     # Caminho base com e sem o domínio
-    base_with_domain = WEBDAV_BASE_URL
-    base_without_domain = WEBDAV_BASE_URL.replace("https://cloud.barch.com.br", "")
+    base_with_domain = unquote(WEBDAV_BASE_URL)
+    base_without_domain = unquote(
+        WEBDAV_BASE_URL.replace("https://cloud.barch.com.br", "")
+    )
 
     if path.startswith(base_with_domain):
         path = path[len(base_with_domain):]
@@ -60,8 +62,7 @@ def list_notes():
         if "Attachments" in path or "Readwise" in path:
             continue
 
-        base_path = unquote(WEBDAV_BASE_URL.replace("https://cloud.barch.com.br", ""))
-        rel_path = path.replace(base_path, "").strip("/")
+        rel_path = to_relative_path(elem.text)
 
         if folder_filter and not rel_path.startswith(folder_filter):
             continue


### PR DESCRIPTION
## Summary
- unquote `WEBDAV_BASE_URL` and its domain-free variant when computing relative paths
- reuse `to_relative_path` inside `list_notes`
- ensure tests still pass

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855adebe0308325a761d31df7130892