### PR TITLE
Fix tests and path resolution

### DIFF
--- a/obsidian_api.py
+++ b/obsidian_api.py
@@ -26,8 +26,12 @@ def to_relative_path(raw_path: str) -> str:
     path = unquote(raw_path)
 
     # Caminho base com e sem o domínio
-    base_with_domain = WEBDAV_BASE_URL
-    base_without_domain = WEBDAV_BASE_URL.replace("https://cloud.barch.com.br", "")
+    # As URLs podem conter espaços codificados (%20). Para comparar corretamente
+    # com o caminho já decodificado acima, também decodificamos os valores de base
+    base_with_domain = unquote(WEBDAV_BASE_URL)
+    base_without_domain = unquote(
+        WEBDAV_BASE_URL.replace("https://cloud.barch.com.br", "")
+    )
 
     if path.startswith(base_with_domain):
         path = path[len(base_with_domain):]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Ensure project root is on sys.path for test imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))


### PR DESCRIPTION
## Summary
- ensure project root is on `sys.path` during tests
- fix `to_relative_path` when comparing URL paths

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6855ae0553188325876dd165e5fec9fb