### PR TITLE
Add search notes test and fix path normalization

### DIFF
--- a/obsidian_api.py
+++ b/obsidian_api.py
@@ -29,10 +29,15 @@ def to_relative_path(raw_path: str) -> str:
     base_with_domain = WEBDAV_BASE_URL
     base_without_domain = WEBDAV_BASE_URL.replace("https://cloud.barch.com.br", "")
 
-    if path.startswith(base_with_domain):
-        path = path[len(base_with_domain):]
-    elif path.startswith(base_without_domain):
-        path = path[len(base_without_domain):]
+    # Comparações devem ocorrer em valores decodificados para abranger ambos os
+    # formatos retornados pelo WebDAV
+    base_with_domain_unquoted = unquote(base_with_domain)
+    base_without_domain_unquoted = unquote(base_without_domain)
+
+    if path.startswith(base_with_domain_unquoted):
+        path = path[len(base_with_domain_unquoted):]
+    elif path.startswith(base_without_domain_unquoted):
+        path = path[len(base_without_domain_unquoted):]
 
     return path.strip("/")
 


### PR DESCRIPTION
## Summary
- ensure `to_relative_path` handles encoded and decoded paths
- add helper to build PROPFIND responses with many notes
- add test for `/search` endpoint enforcing `max_results`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855adf8dd1c8325b03fddfb558e69dc