### PR TITLE
Implement custom limit for search API

### DIFF
--- a/obsidian_api.py
+++ b/obsidian_api.py
@@ -147,8 +147,7 @@ def search_notes():
 
     tree = ElementTree.fromstring(res.content)
     matches = []
-    count = 0
-    max_results = 30  # Evita travamento com muitos arquivos
+    max_results = int(request.args.get("limit", "30"))  # Evita travamento com muitos arquivos
 
     for elem in tree.findall(".//{DAV:}href"):
         path = unquote(elem.text)
@@ -166,8 +165,7 @@ def search_notes():
                     "path": rel_path,
                     "folder": os.path.dirname(rel_path)
                 })
-                count += 1
-                if count >= max_results:
+                if len(matches) >= max_results:
                     break
         except Exception:
             continue

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -113,3 +113,26 @@ def test_search_notes_limit(client):
     ]
     assert data == {"matches": expected}
     assert mock_get.call_count == 30
+
+
+def test_search_notes_custom_limit(client):
+    with patch(
+        "obsidian_api.requests.request",
+        return_value=propfind_many_response(35),
+    ), patch(
+        "obsidian_api.requests.get",
+        return_value=note_response("match term"),
+    ) as mock_get:
+        from obsidian_api import request as flask_request, search_notes
+
+        flask_request.args = {"term": "match", "limit": "10"}
+        resp = search_notes()
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    expected = [
+        {"name": f"Note{i}.md", "path": f"Note{i}.md", "folder": ""}
+        for i in range(10)
+    ]
+    assert data == {"matches": expected}
+    assert mock_get.call_count == 10


### PR DESCRIPTION
## Summary
- allow `/search` to accept a `limit` argument for controlling number of results
- update search logic to respect this parameter
- test default and custom limit behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b2ba17ac8325b18b1ea69bff987b