### PR TITLE
Add markdown header when saving notes

### DIFF
--- a/obsidian_api.py
+++ b/obsidian_api.py
@@ -195,7 +195,13 @@ def create_or_update_note():
         filename = to_relative_path(filename)
 
     file_url = WEBDAV_BASE_URL + quote(filename)
-    res = requests.put(file_url, data=content.encode("utf-8"), auth=AUTH)
+    headers = {"Content-Type": "text/markdown"}
+    res = requests.put(
+        file_url,
+        data=content.encode("utf-8"),
+        auth=AUTH,
+        headers=headers,
+    )
 
     if res.status_code in [200, 201, 204]:
         return jsonify({"message": "Nota salva com sucesso"})

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from obsidian_api import app, WEBDAV_BASE_URL
+from obsidian_api import app, WEBDAV_BASE_URL, AUTH
 
 BASE_PATH = WEBDAV_BASE_URL.replace("https://cloud.barch.com.br", "")
 
@@ -65,13 +65,19 @@ def test_get_note(client):
     assert resp.get_json() == {"content": "Hello"}
 
 def test_create_note(client):
-    with patch("obsidian_api.requests.put", return_value=put_response()):
+    with patch("obsidian_api.requests.put", return_value=put_response()) as mock_put:
         resp = client.post(
             "/note",
             json={"filename": "New.md", "content": "Hi"},
         )
     assert resp.status_code == 200
     assert resp.get_json() == {"message": "Nota salva com sucesso"}
+    mock_put.assert_called_once_with(
+        WEBDAV_BASE_URL + "New.md",
+        data=b"Hi",
+        auth=AUTH,
+        headers={"Content-Type": "text/markdown"},
+    )
 
 
 def test_get_note_not_found(client):


### PR DESCRIPTION
## Summary
- send `Content-Type: text/markdown` header when saving a note
- verify header in `test_create_note`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855b2be903c8325b561990cc2aa0a84