### PR TITLE
Add ping route and test

### DIFF
--- a/obsidian_api.py
+++ b/obsidian_api.py
@@ -9,6 +9,11 @@ import os
 app = Flask(__name__)
 CORS(app)
 
+# === HEALTH CHECK ===
+@app.route("/ping")
+def ping():
+    return jsonify({"status": "ok"})
+
 # === CONFIGURAÇÕES ===
 # These values can be configured via environment variables. The defaults
 # reflect the development configuration used for tests.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -39,6 +39,12 @@ def client():
     with app.test_client() as client:
         yield client
 
+
+def test_ping(client):
+    resp = client.get("/ping")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "ok"}
+
 def test_list_notes(client):
     with patch("obsidian_api.requests.request", return_value=propfind_response()):
         resp = client.get("/notes")


### PR DESCRIPTION
## Summary
- expose a `/ping` health check route
- test `/ping` endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b2c2935883259b70ecffcd96447a